### PR TITLE
Update webapp.py

### DIFF
--- a/client/src/webapp.py
+++ b/client/src/webapp.py
@@ -23,8 +23,13 @@ import configparser
 import requests
 
 from flask import Flask, render_template, redirect, request
-from werkzeug import secure_filename
 from database import Database
+
+try:
+    from werkzeug import secure_filename
+except:
+    from werkzeug.utils import secure_filename
+    pass
 
 config = configparser.ConfigParser()
 config.read("config.ini")


### PR DESCRIPTION
This version (and I'm assuming newer versions) of werkzeug requires the subclass of utils -- this is just a quick fix to ensure that this should work with multiple versions.